### PR TITLE
Add icon to event profiler

### DIFF
--- a/Assets/Plugins/CandyCoded/Scripts/CustomEditor/EventProfiler.cs
+++ b/Assets/Plugins/CandyCoded/Scripts/CustomEditor/EventProfiler.cs
@@ -77,6 +77,8 @@ namespace CandyCoded
         private void OnGUI()
         {
 
+            bool eventsFound = false;
+
             if (currentActiveGameObject)
             {
 
@@ -97,20 +99,17 @@ namespace CandyCoded
 
                             DrawEvents(ev, methods);
 
+                            eventsFound = true;
+
                         }
 
                     }
 
                 }
-                else
-                {
-
-                    GUILayout.Label(noContentTemplate, EditorStyles.helpBox);
-
-                }
 
             }
-            else
+
+            if (!eventsFound)
             {
 
                 GUILayout.Label(noContentTemplate, EditorStyles.helpBox);

--- a/Assets/Plugins/CandyCoded/Scripts/CustomEditor/EventProfiler.cs
+++ b/Assets/Plugins/CandyCoded/Scripts/CustomEditor/EventProfiler.cs
@@ -128,47 +128,6 @@ namespace CandyCoded
 
         }
 
-#pragma warning restore S100
-
-#pragma warning disable S1144
-        // Disables "Unused private types or members should be removed" warning as those methods are defined by Unity.
-
-#pragma warning disable S2325
-        // Disables "Methods and properties that don't access instance data should be static" warning as those methods are defined by Unity.
-
-        private void HandleSelectionChanged()
-        {
-
-            if (!inspectorLocked)
-            {
-
-                currentActiveGameObject = Selection.activeGameObject;
-
-            }
-
-            Repaint();
-
-        }
-
-        private void OnEnable()
-        {
-            prefabIcon = EditorGUIUtility.FindTexture("Prefab Icon");
-
-            Selection.selectionChanged += HandleSelectionChanged;
-
-        }
-
-        private void OnDisable()
-        {
-
-            Selection.selectionChanged -= HandleSelectionChanged;
-
-        }
-
-#pragma warning restore S2325
-
-#pragma warning restore S1144
-
         private void DrawEvents(EventInfo ev, List<ExtendedMethodInfo> methods)
         {
 
@@ -240,6 +199,47 @@ namespace CandyCoded
             return new List<ExtendedMethodInfo>();
 
         }
+
+#pragma warning restore S100
+
+#pragma warning disable S1144
+        // Disables "Unused private types or members should be removed" warning as those methods are defined by Unity.
+
+#pragma warning disable S2325
+        // Disables "Methods and properties that don't access instance data should be static" warning as those methods are defined by Unity.
+
+        private void HandleSelectionChanged()
+        {
+
+            if (!inspectorLocked)
+            {
+
+                currentActiveGameObject = Selection.activeGameObject;
+
+            }
+
+            Repaint();
+
+        }
+
+        private void OnEnable()
+        {
+            prefabIcon = EditorGUIUtility.FindTexture("Prefab Icon");
+
+            Selection.selectionChanged += HandleSelectionChanged;
+
+        }
+
+        private void OnDisable()
+        {
+
+            Selection.selectionChanged -= HandleSelectionChanged;
+
+        }
+
+#pragma warning restore S2325
+
+#pragma warning restore S1144
 
     }
 

--- a/Assets/Plugins/CandyCoded/Scripts/CustomEditor/EventProfiler.cs
+++ b/Assets/Plugins/CandyCoded/Scripts/CustomEditor/EventProfiler.cs
@@ -45,6 +45,8 @@ namespace CandyCoded
 
         private Dictionary<string, Vector2> scrollPositions = new Dictionary<string, Vector2>();
 
+        private Texture2D prefabIcon;
+
         private bool inspectorLocked;
 
         private GameObject currentActiveGameObject;
@@ -150,6 +152,7 @@ namespace CandyCoded
 
         private void OnEnable()
         {
+            prefabIcon = EditorGUIUtility.FindTexture("Prefab Icon");
 
             Selection.selectionChanged += HandleSelectionChanged;
 
@@ -187,12 +190,23 @@ namespace CandyCoded
                 for (var i = 0; i < methods.Count; i += 1)
                 {
 
+                    GUILayout.BeginHorizontal();
+
+                    if (GUILayout.Button(prefabIcon, EditorStyles.label, GUILayout.Width(EditorGUIUtility.singleLineHeight), GUILayout.Height(EditorGUIUtility.singleLineHeight)))
+                    {
+
+                        Selection.activeGameObject = methods[i].gameObject;
+
+                    }
+
                     if (GUILayout.Button(string.Format(eventListItemTemplate, i + 1, methods[i].label), EditorStyles.label))
                     {
 
                         Selection.activeGameObject = methods[i].gameObject;
 
                     }
+
+                    GUILayout.EndHorizontal();
 
                 }
 


### PR DESCRIPTION
Make sure help box always shows up when selecting a gameObject with no events.